### PR TITLE
add virtualConsole in jsdom env

### DIFF
--- a/test/root.js
+++ b/test/root.js
@@ -9,7 +9,10 @@ before(function(done) {
     presets: ['es2015']
   });
 
-  jsdom.env('<div></div>', [], {src: babelResult.code}, (err, window) => {
+  jsdom.env('<div></div>', [], {
+    src: babelResult.code, 
+    virtualConsole: jsdom.createVirtualConsole().sendTo(console)
+  }, (err, window) => {
     if (err) {
       return done(err);
     }


### PR DESCRIPTION
A student with the correct code for this lab was failing two tests that used JS `console` spies. 

Example:

```
  1) logShout(string) calls console.log() its one argument in all caps:                                              
     Error: spy was never called with [ 'HELLO' ]                                                                    
      at assert (node_modules/expect/lib/assert.js:29:9)                                                             
      at Expectation.toHaveBeenCalledWith (node_modules/expect/lib/Expectation.js:333:28)                            
      at Context.<anonymous> (test/index-test.js:20:17)
```

I suspect every student will face this problem. I was able to fix it by adding a `virtualConsole` config in `root.js` (copied from the solution branch). 

// @aturkewi @PeterBell 
